### PR TITLE
chore(deps): Update pre-commit hooks deps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_language_version:
-    python: python3.11
+    python: python3.13
 fail_fast: true
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -13,6 +13,6 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 -   repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
     -   id: shellcheck


### PR DESCRIPTION
- Official hooks: `https://github.com/pre-commit/pre-commit-hooks` to `v6.0.0`
- Shellcheck: `https://github.com/shellcheck-py/shellcheck-py` to `v0.11.0.1`
- Python: to 3.13 (it should have been updated in #11)